### PR TITLE
Upgrade to v.0.6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>angular-strap</artifactId>
-    <version>0.6.4-SNAPSHOT</version>
+    <version>0.6.6-SNAPSHOT</version>
     <name>AngularStrap</name>
     <description>WebJar for AngularStrap</description>
     <url>http://webjars.org</url>
@@ -54,7 +54,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>0.6.3</upstream.version>
+        <upstream.version>0.6.6</upstream.version>
         <upstream.url>https://raw.github.com/mgcrea/angular-strap/v${upstream.version}/dist</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
     </properties>


### PR DESCRIPTION
They're still using an old version of bootstrap (2.2.2) and old version of angular (1.1.2).
